### PR TITLE
Fixed Underscores in Names & Error Caused by Ingots/Nuggets

### DIFF
--- a/src/app/components/AlloyComponentDisplay.tsx
+++ b/src/app/components/AlloyComponentDisplay.tsx
@@ -75,7 +75,7 @@ export function AlloyComponentDisplay({alloy} : Readonly<AlloyDisplayProps>) {
 							if (mineralName.toLowerCase().includes('ingot')) {
 								mineral = ingotOverride(baseMineralName);
 							} else if (mineralName.toLowerCase().includes('nugget')) {
-								mineral = mineral = nuggetOverride(baseMineralName);
+								mineral = nuggetOverride(baseMineralName);
 							}
 						}
 

--- a/src/app/functions/utils.ts
+++ b/src/app/functions/utils.ts
@@ -1,3 +1,16 @@
-export function capitaliseFirstLetter(input : string) : string {
-	return input[0].toUpperCase() + input.substring(1, input.length).toLowerCase();
+export function capitaliseFirstLetterOfEachWord(input: string): string {
+	if (!input) return input;
+
+	return input
+			.split(/[ _]+/)
+			.map(word => word.charAt(0).toUpperCase() + word.slice(1))
+			.join(' ');
+}
+
+export function getBaseMineralFromOverride(mineralName: string): string {
+	return mineralName
+			.toLowerCase()
+			.replace(' ingot', '')
+			.replace(' nugget', '')
+			.replace(' ', '_');
 }


### PR DESCRIPTION
## Description
Fixed issue where names of components and minerals were shown with an underscore.
Fixed issue where ingots and nuggets threw an error, since they could not be found in the API.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Documentation update

## How Has This Been Tested?
Local testing

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
[//]: # (Add any additional information or context about the pull request here)
