### PR TITLE
75 enter keybind on pc

### DIFF
--- a/src/app/[type]/[id]/[version]/metals/page.tsx
+++ b/src/app/[type]/[id]/[version]/metals/page.tsx
@@ -4,7 +4,7 @@ import {SmeltingOutput, SmeltingOutputType} from "@/types";
 import {useParams, useRouter} from "next/navigation";
 import {HeadingWithBackButton} from "@/components/HeadingWithBackButton";
 import {SelfCenteringGrid} from "@/components/SelfCenteringGrid";
-import React, {useCallback, useEffect, useState, useRef} from "react";
+import React, {useCallback, useEffect, useState} from "react";
 import {ErrorComponent} from "@/components/ErrorComponent";
 import {LoadingSpinner} from "@/components/LoadingSpinner";
 import {capitaliseFirstLetterOfEachWord} from "@/functions/utils";
@@ -23,7 +23,6 @@ export default function Home() {
 	const [error, setError] = useState<string | null>(null);
 	const [filterType, setFilterType] = useState<CreationSelectionFilter>(CreationSelectionFilter.All);
 	const [searchTerm, setSearchTerm] = useState("");
-	const containerRef = useRef<HTMLDivElement>(null);
 
 	const handleMetalSelect = useCallback((metal : SmeltingOutput) => {
 		router.push(`/${type}/${id}/${version}/${metal.name}`);
@@ -121,8 +120,6 @@ export default function Home() {
 					className="container mx-auto px-4 py-8"
 					role="main"
 					aria-label="Metal Selection"
-					ref={containerRef}
-					tabIndex={-1}
 			>
 				<div className="max-w-6xl mx-auto">
 					<HeadingWithBackButton


### PR DESCRIPTION
## Description
[//]: # (Provide a brief description of the changes in this pull request)
Provided an enter key functionality to activate when only one filter result is visible.
Added a keyboard icon for reference and UX response.

<img width="1524" height="612" alt="image" src="https://github.com/user-attachments/assets/1de6a7ab-3e2d-4a3f-b486-9dea9e1a4d4b" />

## Type of change
- [ ] Bug fix
- [x] New feature
- [x] Enhancement
- [ ] Documentation update

## How Has This Been Tested?
[//]: # (Describe the tests you ran to verify your changes)
Tested manually

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
[//]: # (Add any additional information or context about the pull request here)
